### PR TITLE
Implementation of RSwag for API documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ gem 'devise'
 # handle auth for api
 gem 'devise-jwt'
 
+# generate API Documentation from test
+gem 'rswag'
+
 # handle json reponse
 gem 'fast_jsonapi'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     backport (1.2.0)
     bcrypt (3.1.18)
@@ -112,6 +114,8 @@ GEM
       reline (>= 0.3.0)
     jaro_winkler (1.5.4)
     json (2.6.3)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     jwt (2.6.0)
     kramdown (2.4.0)
       rexml
@@ -147,6 +151,7 @@ GEM
     parser (3.2.0.0)
       ast (~> 2.4.1)
     pg (1.4.5)
+    public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -209,6 +214,20 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    rswag (2.8.0)
+      rswag-api (= 2.8.0)
+      rswag-specs (= 2.8.0)
+      rswag-ui (= 2.8.0)
+    rswag-api (2.8.0)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.8.0)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.8.0)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.42.0)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -272,6 +291,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.0.4)
   rspec-rails
+  rswag
   rubocop
   solargraph
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    minitest (5.17.0)
+    minitest (5.15.0)
     msgpack (1.6.0)
     net-imap (0.3.4)
       date
@@ -154,7 +154,7 @@ GEM
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
-    racc (1.6.2)
+    racc (1.6.0)
     rack (2.2.5)
     rack-cors (1.1.1)
       rack (>= 2.0.0)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,4 @@
 class UserSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :email, :name, :role, :created_at
+  attributes :id, :email, :name, :role
 end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
 
   devise_for :users, path: '', path_names: {
     sign_in: 'login',

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,67 @@
+# rubocop:disable Metrics/BlockLength
+require 'swagger_helper'
+
+RSpec.describe 'users/registrations', type: :request do
+  let!(:test_user_email) do
+    'test_user_name@rspec.com'
+  end
+
+  let!(:test_user_password) do
+    'password'
+  end
+
+  let!(:test_user_name) do
+    'test_user_name'
+  end
+
+  path '/signup' do
+    post 'signup' do
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :cretentials, in: :body, schema: {
+        type: :object,
+        properties: {
+          user: {
+            type: :object,
+            properties: {
+              email: { type: :string },
+              password: { type: :string },
+              name: { type: :string }
+            }
+          }
+        },
+        required: %w[
+          email
+          password
+          name
+        ]
+      }
+
+      response 200, 'OK' do
+        header 'Authorization',
+               schema: :bearer,
+               description: 'bearer token'
+
+        schema type: :object, properties: {
+          status: { '$ref' => '#/components/schemas/status' },
+          data: {}
+        }
+
+        let(:cretentials) do
+          {
+            user: {
+              email: test_user_email,
+              password: test_user_password,
+              name: test_user_name
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+  end
+end
+
+# rubocop:enable Metrics/BlockLength

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -2,17 +2,9 @@
 require 'swagger_helper'
 
 RSpec.describe 'users/registrations', type: :request do
-  let!(:test_user_email) do
-    'test_user_name@rspec.com'
-  end
-
-  let!(:test_user_password) do
-    'password'
-  end
-
-  let!(:test_user_name) do
-    'test_user_name'
-  end
+  let!(:user_name) { 'Swagger' }
+  let!(:user_email) { 'swagger@rswag.com' }
+  let!(:user_password) { 'swagger123' }
 
   path '/signup' do
     post 'signup' do
@@ -25,9 +17,9 @@ RSpec.describe 'users/registrations', type: :request do
           user: {
             type: :object,
             properties: {
-              email: { type: :string },
-              password: { type: :string },
-              name: { type: :string }
+              name: { type: :string, example: 'Swagger' },
+              email: { type: :string, example: 'swagger@rswag.com' },
+              password: { type: :string, example: 'swagger123' }
             }
           }
         },
@@ -40,7 +32,7 @@ RSpec.describe 'users/registrations', type: :request do
 
       response 200, 'OK' do
         header 'Authorization',
-               schema: :bearer,
+               schema: { type: :string },
                description: 'bearer token'
 
         schema type: :object, properties: {
@@ -51,9 +43,9 @@ RSpec.describe 'users/registrations', type: :request do
         let(:cretentials) do
           {
             user: {
-              email: test_user_email,
-              password: test_user_password,
-              name: test_user_name
+              name: user_name,
+              email: user_email,
+              password: user_password
             }
           }
         end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,108 @@
+# rubocop:disable Metrics/BlockLength
+require 'swagger_helper'
+
+RSpec.describe 'Blogs API', type: :request do
+  let!(:user_name) { 'Swagger' }
+  let!(:user_email) { 'swagger@rswag.com' }
+  let!(:user_password) { 'swagger123' }
+
+  let!(:test_person) do
+    User.create(
+      name: user_name,
+      email: user_email,
+      password: user_password
+    )
+  end
+
+  describe 'login' do
+    path '/login' do
+      post 'login' do
+        consumes 'application/json'
+        produces 'application/json'
+
+        parameter name: :cretentials, in: :body, schema: {
+          type: :object,
+          properties: {
+            user: {
+              type: :object,
+              properties: {
+                email: { type: :string, example: 'swagger@rswag.com' },
+                password: { type: :string, example: 'swagger123' }
+              }
+            }
+          },
+          required: %w[
+            email
+            password
+          ]
+        }
+
+        response 200, 'OK' do
+          header 'Authorization',
+                 schema: { type: :string },
+                 description: 'bearer token'
+
+          schema type: :object, properties: {
+            status: { '$ref' => '#/components/schemas/status' }
+          }
+
+          let(:cretentials) do
+            {
+              user: {
+                email: user_email,
+                password: user_password
+              }
+            }
+          end
+
+          run_test!
+        end
+
+        response 401, 'Invalid Email or password.' do
+          schema type: :object, properties: {
+            error: { type: :string, example: 'Invalid Email or password.' }
+          }
+
+          let(:cretentials) do
+            {
+              user: {
+                email: 'user_email',
+                password: 'user_password'
+              }
+            }
+          end
+
+          run_test!
+        end
+      end
+    end
+  end
+
+  describe 'logout' do
+    path '/logout' do
+      delete 'logout' do
+        consumes 'application/json'
+        produces 'application/json'
+
+        security [{ bearer_auth: [] }]
+
+        response 401, 'Unauthorized' do
+          let(:Authorization) { '' }
+          run_test!
+        end
+
+        response 200, 'OK' do
+          schema '$ref' => '#/components/schemas/status'
+
+          let(:Authorization) do
+            Devise::JWT::TestHelpers.auth_headers({}, test_person)['Authorization']
+          end
+
+          run_test!
+        end
+      end
+    end
+  end
+end
+
+# rubocop:enable Metrics/BlockLength

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,14 +2,11 @@ require 'swagger_helper'
 
 RSpec.describe 'Users', type: :request do
   let!(:test_person) do
-    let_p = User.new(
+    User.create(
       name: 'rspec',
       email: 'rspec@rspec.com',
       password: '123rspec123'
     )
-    let_p.save
-
-    let_p
   end
 
   path '/users/current' do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,34 +1,37 @@
-require 'rails_helper'
+require 'swagger_helper'
 
 RSpec.describe 'Users', type: :request do
-  describe 'GET /current' do
-    context 'with out auth token' do
-      it 'returns http unauthorized' do
-        get '/users/current'
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
+  let!(:test_person) do
+    let_p = User.new(
+      name: 'rspec',
+      email: 'rspec@rspec.com',
+      password: '123rspec123'
+    )
+    let_p.save
 
-    context 'with auth token' do
-      let!(:user) do
-        User.create(
-          name: 'rspec',
-          email: 'rspec@rspec.com',
-          password: '123rspec123'
-        )
-      end
+    let_p
+  end
 
-      before(:each) do
-        headers = {
-          'Accept' => 'application/json',
-          'Content-Type' => 'application/json'
-        }
-        auth_headers = Devise::JWT::TestHelpers.auth_headers(headers, user)
-        get '/users/current', headers: auth_headers
+  path '/users/current' do
+    get 'Current user' do
+      consumes 'application/json'
+      produces 'application/json'
+
+      security [{ bearer_auth: [] }]
+
+      response 401, 'Unauthorized' do
+        let(:Authorization) { '' }
+        run_test!
       end
 
-      it 'returns http unauthorized' do
-        expect(response).to have_http_status(:ok)
+      response 200, 'OK' do
+        schema '$ref' => '#/components/schemas/User'
+
+        let(:Authorization) do
+          Devise::JWT::TestHelpers.auth_headers({}, test_person)['Authorization']
+        end
+
+        run_test!
       end
     end
   end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 RSpec.configure do |config|
@@ -37,11 +35,11 @@ RSpec.configure do |config|
               role: { type: :string, example: 'user' }
             }
           },
-          ErrorResponse: {
+          status: {
             type: :object,
             properties: {
-              type: :array,
-              items: { type: :string }
+              code: { type: :integer, example: 200 },
+              message: { type: :string, example: 'Signed up sucessfully.' }
             }
           }
         }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/BlockLength
 require 'rails_helper'
 
 RSpec.configure do |config|
@@ -41,6 +42,13 @@ RSpec.configure do |config|
               code: { type: :integer, example: 200 },
               message: { type: :string, example: 'Signed up sucessfully.' }
             }
+          },
+          ErrorResponses: {
+            type: :object,
+            properties: {
+              type: :array,
+              items: { type: :string }
+            }
           }
         }
       }
@@ -53,3 +61,5 @@ RSpec.configure do |config|
   # Defaults to json. Accepts ':json' and ':yaml'.
   config.swagger_format = :yaml
 end
+
+# rubocop:enable Metrics/BlockLength

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -18,20 +18,34 @@ RSpec.configure do |config|
     'v1/swagger.yaml' => {
       openapi: '3.0.1',
       info: {
-        title: 'API V1',
-        version: 'v1'
+        title: 'DOCTOR RESERVATION API'
       },
-      paths: {},
-      servers: [
-        {
-          url: 'https://{defaultHost}',
-          variables: {
-            defaultHost: {
-              default: 'www.example.com'
+      components: {
+        securitySchemes: {
+          bearer_auth: {
+            type: :http,
+            scheme: :bearer
+          }
+        },
+        schemas: {
+          User: {
+            type: :object,
+            properties: {
+              id: { type: :integer, example: 2 },
+              name: { type: :string, example: 'Scott Wells' },
+              email: { type: :string, example: 'scott_wells@test.com' },
+              role: { type: :string, example: 'user' }
+            }
+          },
+          ErrorResponse: {
+            type: :object,
+            properties: {
+              type: :array,
+              items: { type: :string }
             }
           }
         }
-      ]
+      }
     }
   }
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,88 @@
+---
+openapi: 3.0.1
+info:
+  title: DOCTOR RESERVATION API
+components:
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 2
+        name:
+          type: string
+          example: Scott Wells
+        email:
+          type: string
+          example: scott_wells@test.com
+        role:
+          type: string
+          example: user
+    status:
+      type: object
+      properties:
+        code:
+          type: integer
+          example: 200
+        message:
+          type: string
+          example: Signed up sucessfully.
+paths:
+  "/signup":
+    post:
+      summary: signup
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          headers:
+            Authorization:
+              schema:
+                type: string
+              description: bearer token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    "$ref": "#/components/schemas/status"
+                  data: {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                    password:
+                      type: string
+                    name:
+                      type: string
+              required:
+              - email
+              - password
+              - name
+  "/users/current":
+    get:
+      summary: Current user
+      security:
+      - bearer_auth: []
+      responses:
+        '401':
+          description: Unauthorized
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -32,6 +32,12 @@ components:
         message:
           type: string
           example: Signed up sucessfully.
+    ErrorResponses:
+      type: object
+      properties:
+        type: array
+        items:
+          type: string
 paths:
   "/signup":
     post:
@@ -62,16 +68,80 @@ paths:
                 user:
                   type: object
                   properties:
-                    email:
-                      type: string
-                    password:
-                      type: string
                     name:
                       type: string
+                      example: Swagger
+                    email:
+                      type: string
+                      example: swagger@rswag.com
+                    password:
+                      type: string
+                      example: swagger123
               required:
               - email
               - password
               - name
+  "/login":
+    post:
+      summary: login
+      parameters: []
+      responses:
+        '200':
+          description: OK
+          headers:
+            Authorization:
+              schema:
+                type: string
+              description: bearer token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    "$ref": "#/components/schemas/status"
+        '401':
+          description: Invalid Email or password.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Invalid Email or password.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                      example: swagger@rswag.com
+                    password:
+                      type: string
+                      example: swagger123
+              required:
+              - email
+              - password
+  "/logout":
+    delete:
+      summary: logout
+      security:
+      - bearer_auth: []
+      responses:
+        '401':
+          description: Unauthorized
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/status"
   "/users/current":
     get:
       summary: Current user


### PR DESCRIPTION
# Implementation of RSwag for API documentation

- Implementation of RSwag 
- Add RSpec for request
  - auth
  - current user 
- generate swagger UI from request RSpec
- Swagger UI URL: http://localhost:3000/api-docs
## screenshot
![imagen](https://user-images.githubusercontent.com/34493013/211101720-f5ffdd35-a176-403d-aca2-811be5d0f404.png)


# issues

- close #6